### PR TITLE
Display 'Draw' Message When No Winner is Found [ issue #13 ]

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,20 +25,34 @@ const checkwin = () => {
         [0, 4, 8], [2, 4, 6]              // Diagonals
     ];
 
+    let winnerFound = false;
+    
     wins.forEach(e => {
         if (
+            boxtext[e[0]].innerText !== "" &&
             boxtext[e[0]].innerText === boxtext[e[1]].innerText &&
-            boxtext[e[1]].innerText === boxtext[e[2]].innerText &&
-            boxtext[e[0]].innerText !== ""
+            boxtext[e[1]].innerText === boxtext[e[2]].innerText
         ) {
             info.innerText = boxtext[e[0]].innerText + " Won!";
             isgameover = true;
             gameover.play();
             document.querySelector('.imgbox img').style.width = "200px";
             disableBoxes();
+            winnerFound = true;
         }
     });
+
+    // Check for Draw if No Winner is Found
+    if (!winnerFound) {
+        let allFilled = [...boxtext].every(box => box.innerText !== "");
+        if (allFilled) {
+            info.innerText = "It's a Draw!";
+            isgameover = true;
+            gameover.play();
+        }
+    }
 };
+
 
 // Disable All Boxes
 const disableBoxes = () => {


### PR DESCRIPTION
This update improves the game logic by displaying a "Draw" message when all cells are filled and no winner is determined. Previously, the game did not explicitly indicate a tie, which could lead to confusion for players.

### Changes Made:

- Added a condition to check if all cells are occupied without a winner.
- Implemented a message display to notify players when the game ends in a draw.
- Ensured smooth UI integration without affecting existing game functionality.

### Impact:
This enhancement improves user experience by providing clear game results in all possible scenarios.


![image](https://github.com/user-attachments/assets/7c31516e-3caf-4708-a6fc-c706be36b196)





